### PR TITLE
Api for /subjects and /subjects/:id

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -1,5 +1,8 @@
 module API
   class Base < Grape::API
+    formatter :json, API::Formatters::SuccessFormatter
+    error_formatter :json, API::Formatters::ErrorFormatter
+
     mount API::V1::Base
   end
 end

--- a/app/controllers/api/entities/subject.rb
+++ b/app/controllers/api/entities/subject.rb
@@ -1,0 +1,19 @@
+module API
+  module Entities
+    class Subject < Grape::Entity
+      expose :id
+      expose :name
+      expose :description
+      expose :question_amount
+      expose :question_bank_amount do |subject|
+        subject.questions.size
+      end
+      expose :pass_score
+      expose :test_duration
+      expose :user_id
+      expose :created_at
+      expose :updated_at
+      expose :deleted_at, expose_nil: false
+    end
+  end
+end

--- a/app/controllers/api/formatters.rb
+++ b/app/controllers/api/formatters.rb
@@ -1,0 +1,19 @@
+module API
+  module Formatters
+    module SuccessFormatter
+      def self.call object, _env
+        {status: "success", data: object}.to_json
+      end
+    end
+
+    module ErrorFormatter
+      def self.call message, _backtrace, _options, _env, _original_exception
+        if message.is_a?(Hash)
+          {status: "fail", data: message}.to_json
+        else
+          {status: "error", message: message}.to_json
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -4,6 +4,7 @@ module API
   module V1
     class Base < Grape::API
       mount API::V1::HealthCheck
+      mount API::V1::Subjects
       add_swagger_documentation(
         api_version: "v1",
         hide_documentation_path: true,

--- a/app/controllers/api/v1/defaults.rb
+++ b/app/controllers/api/v1/defaults.rb
@@ -8,6 +8,30 @@ module API
         version "v1", using: :path
         default_format :json
         format :json
+
+        rescue_from ActiveRecord::RecordNotFound do |e|
+          raise e if Rails.env.development?
+
+          error_response(message: e.message, status: 404)
+        end
+
+        rescue_from ActiveRecord::StatementInvalid do |e|
+          raise e if Rails.env.development?
+
+          error_response(message: "Invalid parameters", status: 400)
+        end
+
+        rescue_from Grape::Exceptions::ValidationErrors do |e|
+          raise e if Rails.env.development?
+
+          error_response(message: e.message, status: 400)
+        end
+
+        rescue_from :all do |e|
+          raise e if Rails.env.development?
+
+          error_response(message: "Internal server error", status: 500)
+        end
       end
     end
   end

--- a/app/controllers/api/v1/helpers/pagination_helper.rb
+++ b/app/controllers/api/v1/helpers/pagination_helper.rb
@@ -1,0 +1,22 @@
+module API::V1::Helpers::PaginationHelper
+  extend ActiveSupport::Concern
+  extend Grape::API::Helpers
+
+  included do
+    helpers do
+      params :pagination do
+        optional :page, type: Integer, desc: "Page number"
+        optional :per_page,
+                 type: Integer,
+                 desc: "Per page count"
+      end
+
+      def paginate collection
+        return collection unless params[:page] && params[:per_page]
+
+        collection.limit(params[:per_page])
+                  .offset((params[:page] - 1) * params[:per_page])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/subjects.rb
+++ b/app/controllers/api/v1/subjects.rb
@@ -1,0 +1,29 @@
+module API
+  module V1
+    class Subjects < Grape::API
+      include API::V1::Defaults
+      include API::V1::Helpers::PaginationHelper
+
+      resource :subjects do
+        desc "Return all subjects"
+        params do
+          use :pagination
+        end
+        get "", root: :subjects do
+          subjects = Subject.newest.includes(:questions)
+          subjects = paginate subjects
+          present subjects, with: API::Entities::Subject
+        end
+
+        desc "Return a subject"
+        params do
+          requires :id, type: String, desc: "ID of the subject"
+        end
+        get ":id", root: "subject" do
+          subject = Subject.where(id: params[:id]).first!
+          present subject, with: API::Entities::Subject
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -2,8 +2,8 @@ class TestsController < ApplicationController
   before_action :require_login
   before_action :load_test, :post_data_handle, :true_answers, only: :update
   before_action :load_test_show, only: %i(edit show)
-  before_action :has_authorization_with_test_show, only: :show
-  before_action :has_authorization_with_test_modification,
+  before_action :require_authorization_with_test_show, only: :show
+  before_action :require_authorization_with_test_modification,
                 :require_doing_test, only: %i(edit update)
   before_action :require_finished_test, only: :show
   before_action :post_data_handle, only: :update
@@ -212,7 +212,7 @@ class TestsController < ApplicationController
     params.permit :subject_id
   end
 
-  def has_authorization_with_test_show
+  def require_authorization_with_test_show
     return if current_user.is_supervisor? ||
               current_user.id == @test.user_id
 
@@ -220,7 +220,7 @@ class TestsController < ApplicationController
     redirect_back fallback_location: root_path
   end
 
-  def has_authorization_with_test_modification
+  def require_authorization_with_test_modification
     return if current_user.id == @test.user_id
 
     flash[:danger] = t "tests.show.not_authorized"

--- a/spec/requests/api/v1/health_checks_spec.rb
+++ b/spec/requests/api/v1/health_checks_spec.rb
@@ -1,15 +1,16 @@
 require "rails_helper"
+require "shared_examples"
 
 RSpec.describe API::V1::HealthCheck, type: :request do
-  describe "GET /api/v1/health_check2" do
-    it "returns status 200" do
+  describe "GET /api/v1/health_check" do
+    before do
       get "/api/v1/health_check"
-      expect(response).to have_http_status(200)
     end
+    include_examples "status code 200"
+    include_examples "status success"
 
     it "returns status ok" do
-      get "/api/v1/health_check"
-      expect(JSON.parse(response.body)["status"]).to eq("ok")
+      expect(JSON.parse(response.body)["data"]["status"]).to eq("ok")
     end
   end
 end

--- a/spec/requests/api/v1/subjects_spec.rb
+++ b/spec/requests/api/v1/subjects_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+require "test_prof/recipes/rspec/let_it_be"
+require "shared_examples"
+
+RSpec.describe API::V1::Subjects, type: :request do
+  describe "GET /api/v1/subjects" do
+    let_it_be(:subjects) { create_list(:subject, 15) }
+
+    context "without params" do
+      before do
+        get "/api/v1/subjects"
+      end
+
+      include_examples "status code 200"
+      include_examples "status success"
+
+      it "returns all subjects" do
+        expect(JSON.parse(response.body)["data"].size).to eq(15)
+      end
+    end
+
+    context "with valid params" do
+      context "subjects exists" do
+        before do
+          get "/api/v1/subjects", params: {page: 1, per_page: 10}
+        end
+
+        include_examples "status code 200"
+        include_examples "status success"
+
+        it "returns subjects" do
+          expect(JSON.parse(response.body)["data"].size).to eq(10)
+        end
+      end
+
+      context "subjects does not exist" do
+        before do
+          get "/api/v1/subjects", params: {page: 200, per_page: 10}
+        end
+
+        include_examples "status code 200"
+        include_examples "status success"
+
+        it "returns subjects" do
+          expect(JSON.parse(response.body)["data"].size).to eq(0)
+        end
+      end
+    end
+
+    context "with invalid params" do
+      context "negative page or per_page" do
+        before do
+          get "/api/v1/subjects", params: {page: 1, per_page: -1}
+        end
+
+        it "returns status 400" do
+          expect(response).to have_http_status(400)
+        end
+
+        it "returns error message" do
+          expect(JSON.parse(response.body)["message"]).to eq("Invalid parameters")
+        end
+      end
+
+      context "page or per_page is not a number" do
+        before do
+          get "/api/v1/subjects", params: {page: "abc", per_page: 10}
+        end
+
+        it "returns status 400" do
+          expect(response).to have_http_status(400)
+        end
+
+        it "returns error message" do
+          expect(JSON.parse(response.body)["message"]).to eq("page is invalid")
+        end
+      end
+    end
+  end
+
+  describe "GET /api/v1/subjects/:id" do
+    let(:subject) { create(:subject) }
+
+    context "when subject exists" do
+      before do
+        get "/api/v1/subjects/#{subject.id}"
+      end
+
+      include_examples "status code 200"
+      include_examples "status success"
+
+      it "returns subject" do
+        expect(JSON.parse(response.body)["data"]["id"]).to eq(subject.id)
+      end
+    end
+
+    context "when subject does not exist" do
+      it "returns status 404" do
+        get "/api/v1/subjects/0"
+        expect(response).to have_http_status(404)
+      end
+
+      it "returns error message" do
+        get "/api/v1/subjects/0"
+        expect(JSON.parse(response.body)["message"]).to start_with("Couldn't find Subject with")
+      end
+    end
+  end
+end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -159,3 +159,15 @@ RSpec.shared_examples "handle test completed error" do |method, action, params =
     it_behaves_like "back to home"
   end
 end
+
+RSpec.shared_examples "status code 200" do
+  it "returns status code 200" do
+    expect(response).to have_http_status(200)
+  end
+end
+
+RSpec.shared_examples "status success" do
+  it "returns status success" do
+    expect(JSON.parse(response.body)["status"]).to eq("success")
+  end
+end


### PR DESCRIPTION
## Related Tickets
- [#66668](https://edu-redmine.sun-asterisk.vn/issues/66668)

## WHAT (optional)
- Thêm api và rspec cho route /subjects và /subjects/:id.

## HOW
- Thêm response formatter và error formatter.
- Thêm grape entity cho subject.
- Thêm pagination helper để phân trang.
- Thêm 2 route /subjects và /subjects/:id.

## Evidence (Screenshot or Video)
![image](https://github.com/awesome-academy/naitei18-exam_management_system/assets/73751932/b4a6750b-2955-4fce-a04a-4392c9d36e6e)
![image](https://github.com/awesome-academy/naitei18-exam_management_system/assets/73751932/a4344f44-1ac4-467e-815a-031f2d83ceeb)
