### PR TITLE
fix swagger json format

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -1,8 +1,19 @@
 module API
   class Base < Grape::API
-    formatter :json, API::Formatters::SuccessFormatter
-    error_formatter :json, API::Formatters::ErrorFormatter
-
     mount API::V1::Base
+    add_swagger_documentation(
+      api_version: "v1",
+      hide_documentation_path: true,
+      mount_path: "/api/v1/swagger_doc",
+      schemes: %w(http https),
+      security_definitions: {
+        Bearer: {
+          type: "apiKey",
+          name: "Authorization",
+          in: "header"
+        }
+      },
+      security: [Bearer: []]
+    )
   end
 end

--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -3,17 +3,14 @@ require "grape-swagger"
 module API
   module V1
     class Base < Grape::API
+      formatter :json, API::Formatters::SuccessFormatter
+      error_formatter :json, API::Formatters::ErrorFormatter
       mount API::V1::HealthCheck
       mount API::V1::Subjects
       mount API::V1::Tests
       mount API::V1::Questions
       mount API::V1::Auth
       mount API::V1::Users
-      add_swagger_documentation(
-        api_version: "v1",
-        hide_documentation_path: true,
-        mount_path: "/api/v1/swagger_doc"
-      )
     end
   end
 end


### PR DESCRIPTION
## Related Tickets
- [#66913](https://edu-redmine.sun-asterisk.vn/issues/66913)

## HOW
- Sửa route `/api/v1/swagger_doc` sai format vì dùng formatter.
- Thêm scheme và token hiển thị trong doc.

## Evidence (Screenshot or Video)
![image](https://github.com/awesome-academy/naitei18-exam_management_system/assets/73751932/46b24bd1-9c08-4391-ab9f-c8648b976066)
![image](https://github.com/awesome-academy/naitei18-exam_management_system/assets/73751932/afb2a12a-5edb-4978-a5cf-bf52872cf11f)
